### PR TITLE
Adding support for Embedding Type - Varlena Approach

### DIFF
--- a/pkg/container/types/README.md
+++ b/pkg/container/types/README.md
@@ -4,13 +4,12 @@
 
 There are a couple of strategies of doing this.
 
-1. Using Varlena 
-2. Using Width with Float[]
+1. Using Width with Float[]
 
 Problem: Dealing with TypeSize()
 ```go
 func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
-	sz := int(v.typ.TypeSize()) // What to do for TypeSize()?
+	sz := int(v.typ.TypeSize()) // TypeSize is not defined for FloatVector
 
 	if cap(v.data) >= sz {
 		return unsafe.Slice((*T)(unsafe.Pointer(&v.data[0])), cap(v.data)/sz)
@@ -18,14 +17,25 @@ func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
 	return nil
 }
 ```
+Currently TypeSize() is solved using 
+```go
+func (t Type) TypeSize() int {
+	if t.Oid == T_float32vec {
+		return int(t.Width * t.Size)
+	}
+	return int(t.Size)
+}
+```
 
-3. Using Width without creating a new Oid
+2. Using Width without creating a new Oid
 Problem: 
-Each of the float switch case may now have 2 condition. 1 for regular float, 2 for float vector.
+Each of the float switch case may now have 2 condition: 1 for regular float, 2 for float vector.
 To simplify this, we can define a new Oid and have a new switch case for that Oid.
 
-### Adding support for Create Syntax in Parser
+3. Using Varlena
+Problem: Right now area saves bytes. We may encounter serialization/deserialization overhead.
 
+### Adding support for Create Syntax in Parser
 
 ### Adding support for INSERT/SELECT syntax in Parser and Execution Engine.
 

--- a/pkg/container/types/README.md
+++ b/pkg/container/types/README.md
@@ -1,18 +1,16 @@
-# Embedding
+## Embedding/FloatVector
 
 ### Registering FloatVector to Vector Types.
 
 There are a couple of strategies of doing this.
 
-1. Using Varlena  (suggested by Feng)
-2. Using Width with Float[] (suggested by MoChen) - Good.
+1. Using Varlena 
+2. Using Width with Float[]
+
+Problem: Dealing with TypeSize()
 ```go
 func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
 	sz := int(v.typ.TypeSize()) // What to do for TypeSize()?
-
-	//if cap(v.data)%sz != 0 {
-	//	panic(moerr.NewInternalErrorNoCtx("decode slice that is not a multiple of element size"))
-	//}
 
 	if cap(v.data) >= sz {
 		return unsafe.Slice((*T)(unsafe.Pointer(&v.data[0])), cap(v.data)/sz)
@@ -21,4 +19,24 @@ func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
 }
 ```
 
-3. Using Width without creating a new Oid (suggested by Aungr) - Complex
+3. Using Width without creating a new Oid
+Problem: 
+Each of the float switch case may now have 2 condition. 1 for regular float, 2 for float vector.
+To simplify this, we can define a new Oid and have a new switch case for that Oid.
+
+### Adding support for Create Syntax in Parser
+
+
+### Adding support for INSERT/SELECT syntax in Parser and Execution Engine.
+
+### Implement unary operators like minus, abs etc.
+
+
+### Implement binary operator
+
+### Implement aggregate operator for `Transpose`.
+
+### Start with Indexing Task.
+- Similar to our current compaction task
+- Will be done in CN node.
+- 

--- a/pkg/container/types/README.md
+++ b/pkg/container/types/README.md
@@ -1,0 +1,24 @@
+# Embedding
+
+### Registering FloatVector to Vector Types.
+
+There are a couple of strategies of doing this.
+
+1. Using Varlena  (suggested by Feng)
+2. Using Width with Float[] (suggested by MoChen) - Good.
+```go
+func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
+	sz := int(v.typ.TypeSize()) // What to do for TypeSize()?
+
+	//if cap(v.data)%sz != 0 {
+	//	panic(moerr.NewInternalErrorNoCtx("decode slice that is not a multiple of element size"))
+	//}
+
+	if cap(v.data) >= sz {
+		return unsafe.Slice((*T)(unsafe.Pointer(&v.data[0])), cap(v.data)/sz)
+	}
+	return nil
+}
+```
+
+3. Using Width without creating a new Oid (suggested by Aungr) - Complex

--- a/pkg/container/types/bytes.go
+++ b/pkg/container/types/bytes.go
@@ -30,9 +30,6 @@ const (
 	MaxCharLen        = 255
 	MaxBinaryLen      = 255
 	MaxVarBinaryLen   = 65535
-
-	// Based on here: https://github.com/pgvector/pgvector/blob/b56971febeec389a011de7bb40b3349e24757aff/src/vector.h#L10
-	MaxVecDimension = 16000
 )
 
 func (v *Varlena) UnsafePtr() unsafe.Pointer {

--- a/pkg/container/types/bytes.go
+++ b/pkg/container/types/bytes.go
@@ -30,6 +30,9 @@ const (
 	MaxCharLen        = 255
 	MaxBinaryLen      = 255
 	MaxVarBinaryLen   = 65535
+
+	// Based on here: https://github.com/pgvector/pgvector/blob/b56971febeec389a011de7bb40b3349e24757aff/src/vector.h#L10
+	MaxVecDimension = 16000
 )
 
 func (v *Varlena) UnsafePtr() unsafe.Pointer {

--- a/pkg/container/types/bytes.go
+++ b/pkg/container/types/bytes.go
@@ -103,6 +103,15 @@ func (v *Varlena) GetByteSlice(area []byte) []byte {
 	return area[voff : voff+vlen]
 }
 
+func (v *Varlena) GetEmbedding(area []byte) []float32 {
+	svlen := (*v)[0]
+	if svlen <= VarlenaInlineSize {
+		return BytesToEmbedding(v.ByteSlice())
+	}
+	voff, vlen := v.OffsetLen()
+	return BytesToEmbedding(area[voff : voff+vlen])
+}
+
 // See the lifespan comment above.
 func (v *Varlena) GetString(area []byte) string {
 	return util.UnsafeBytesToString(v.GetByteSlice(area))

--- a/pkg/container/types/embedding.go
+++ b/pkg/container/types/embedding.go
@@ -1,0 +1,81 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"math"
+	"strings"
+)
+
+const (
+	// Based on here: https://github.com/pgvector/pgvector/blob/b56971febeec389a011de7bb40b3349e24757aff/src/vector.h#L10
+	MaxVecDimension = 16000
+)
+
+func (v *Varlena) GetEmbedding(area []byte) []float32 {
+	svlen := (*v)[0]
+	if svlen <= VarlenaInlineSize {
+		return BytesToEmbedding(v.ByteSlice())
+	}
+	voff, vlen := v.OffsetLen()
+	return BytesToEmbedding(area[voff : voff+vlen])
+}
+
+func BytesToEmbedding(input []byte) (res []float32) {
+	if len(input)%4 != 0 {
+		panic(moerr.NewInternalErrorNoCtx("the byte slice length must be a multiple of 4"))
+	}
+
+	dimension := len(input) / 4
+	res = make([]float32, dimension)
+
+	for i := 0; i < dimension; i++ {
+		bits := binary.LittleEndian.Uint32(input[i*4 : (i+1)*4])
+		res[i] = math.Float32frombits(bits)
+	}
+
+	return res
+}
+
+func EmbeddingToBytes(input []float32) []byte {
+	totalBytes := len(input) * 4
+	res := make([]byte, totalBytes)
+
+	for i, val := range input {
+		bits := math.Float32bits(val)
+		binary.LittleEndian.PutUint32(res[i*4:(i+1)*4], bits)
+	}
+	return res
+}
+
+func EmbeddingToString(input []float32) string {
+	var strValues []string
+	for _, value := range input {
+		strValues = append(strValues, fmt.Sprintf("%f", value))
+	}
+
+	return "[" + strings.Join(strValues, ", ") + "]"
+}
+
+func EmbeddingsToString(input [][]float32) string {
+	var strValues []string
+	for _, row := range input {
+		strValues = append(strValues, EmbeddingToString(row))
+	}
+	return strings.Join(strValues, " ")
+}

--- a/pkg/container/types/embedding.go
+++ b/pkg/container/types/embedding.go
@@ -23,18 +23,9 @@ import (
 )
 
 const (
-	// Based on here: https://github.com/pgvector/pgvector/blob/b56971febeec389a011de7bb40b3349e24757aff/src/vector.h#L10
+	// MaxVecDimension Based on here: https://github.com/pgvector/pgvector/blob/b56971febeec389a011de7bb40b3349e24757aff/src/vector.h#L10
 	MaxVecDimension = 16000
 )
-
-func (v *Varlena) GetEmbedding(area []byte) []float32 {
-	svlen := (*v)[0]
-	if svlen <= VarlenaInlineSize {
-		return BytesToEmbedding(v.ByteSlice())
-	}
-	voff, vlen := v.OffsetLen()
-	return BytesToEmbedding(area[voff : voff+vlen])
-}
 
 func BytesToEmbedding(input []byte) (res []float32) {
 	if len(input)%4 != 0 {

--- a/pkg/container/types/embedding_test.go
+++ b/pkg/container/types/embedding_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBytesToEmbedding(t *testing.T) {
+	type args struct {
+		input []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantRes []float32
+	}{
+		{
+			name:    "Test1",
+			args:    args{input: []byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64}},
+			wantRes: []float32{1, 2, 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotRes := BytesToEmbedding(tt.args.input); !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("BytesToEmbedding() = %v, want %v", gotRes, tt.wantRes)
+			}
+		})
+	}
+}
+
+func TestEmbeddingToBytes(t *testing.T) {
+	type args struct {
+		input []float32
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "Test1",
+			args: args{input: []float32{1, 2, 3}},
+			want: []byte{0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmbeddingToBytes(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EmbeddingToBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmbeddingToString(t *testing.T) {
+	type args struct {
+		input []float32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test1",
+			args: args{input: []float32{1, 2, 3}},
+			want: "[1.000000, 2.000000, 3.000000]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmbeddingToString(tt.args.input); got != tt.want {
+				t.Errorf("EmbeddingToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmbeddingsToString(t *testing.T) {
+	type args struct {
+		input [][]float32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test2",
+			args: args{input: [][]float32{{1, 2, 3}, {4, 5, 6}}},
+			want: "[1.000000, 2.000000, 3.000000] [4.000000, 5.000000, 6.000000]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmbeddingsToString(tt.args.input); got != tt.want {
+				t.Errorf("EmbeddingsToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/container/types/types.go
+++ b/pkg/container/types/types.go
@@ -780,7 +780,7 @@ func (t T) TypeLen() int {
 func (t T) FixedLength() int {
 	switch t {
 	case T_any:
-		return 0 //TODO: Can I do this here?
+		return 0
 	case T_int8, T_uint8, T_bool:
 		return 1
 	case T_int16, T_uint16:

--- a/pkg/container/types/types.go
+++ b/pkg/container/types/types.go
@@ -374,7 +374,7 @@ var Types map[string]T = map[string]T{
 	"rowid":                 T_Rowid,
 	"blockid":               T_Blockid,
 
-	"vecf32": T_float32vec,
+	"float vector": T_float32vec,
 }
 
 func New(oid T, width, scale int32) Type {

--- a/pkg/container/vector/tools.go
+++ b/pkg/container/vector/tools.go
@@ -196,6 +196,8 @@ func (v *Vector) setupColFromData() {
 			v.col = DecodeFixedCol[types.Rowid](v)
 		case types.T_Blockid:
 			v.col = DecodeFixedCol[types.Blockid](v)
+		case types.T_float32vec:
+			v.col = DecodeFixedCol[types.Float32Vector](v)
 		default:
 			panic(fmt.Sprintf("unknown type %s", v.typ.Oid))
 		}
@@ -313,6 +315,7 @@ func (v *Vector) CompareAndCheckIntersect(vec *Vector) (bool, error) {
 			return strings.Compare(t1, t2) <= 0
 		})
 	}
+	//TODO: T_float32vec won't be used in zonemap.
 	return false, moerr.NewInternalErrorNoCtx("unsupport type to check intersect")
 }
 
@@ -490,7 +493,7 @@ func (v *Vector) CompareAndCheckAnyResultIsTrue(ctx context.Context, vec *Vector
 	default:
 		return false, moerr.NewInternalErrorNoCtx("unsupport compare type")
 	}
-
+	//TODO: T_float32vec won't be used in zonemap.
 	return false, moerr.NewInternalErrorNoCtx("unsupport compare function")
 }
 
@@ -616,6 +619,7 @@ func MakeAppendBytesFunc(vec *Vector) func([]byte, bool, *mpool.MPool) error {
 		return appendBytesToFixSized[types.Rowid](vec)
 	case types.T_Blockid:
 		return appendBytesToFixSized[types.Blockid](vec)
+		//TODO: Is it required. Need to check
 	}
 	panic(fmt.Sprintf("unexpected type: %s", vec.GetType().String()))
 }

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -32,6 +32,17 @@ func TestLength(t *testing.T) {
 	require.Equal(t, 2, vec.Length())
 	vec.Free(mp)
 	require.Equal(t, int64(0), mp.CurrNB())
+
+	{
+		//Embedding
+		mp := mpool.MustNewZero()
+		vec := NewVec(types.New(types.T_float32vec, 3, 0))
+		err := AppendFixedList(vec, []types.Float32Vector{{1, 2, 3}, {4, 5, 6}}, nil, mp)
+		require.NoError(t, err)
+		require.Equal(t, 2, vec.Length())
+		vec.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestSize(t *testing.T) {
@@ -40,6 +51,14 @@ func TestSize(t *testing.T) {
 	require.Equal(t, 0, vec.Size())
 	vec.Free(mp)
 	require.Equal(t, int64(0), mp.CurrNB())
+	{
+		//Embedding
+		mp := mpool.MustNewZero()
+		vec := NewVec(types.New(types.T_float32vec, 4, 0))
+		require.Equal(t, 0, vec.Size())
+		vec.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestGetUnionOneFunction(t *testing.T) {
@@ -68,6 +87,21 @@ func TestGetUnionOneFunction(t *testing.T) {
 		w.Free(mp)
 		v.Free(mp)
 		require.Equal(t, int64(0), mp.CurrNB())
+	}
+
+	{ // test const embedding vector
+		mp := mpool.MustNewZero()
+		v := NewVec(types.New(types.T_float32vec, 4, 0))
+		w := NewVec(types.New(types.T_float32vec, 4, 0))
+		err := AppendFixedList(w, []types.Float32Vector{{1, 2, 3, 0}, {4, 5, 6, 0}}, nil, mp)
+		require.NoError(t, err)
+		uf := GetUnionOneFunction(*w.GetType(), mp)
+		err = uf(v, w, 0)
+		require.NoError(t, err)
+		w.Free(mp)
+		v.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+
 	}
 }
 
@@ -119,6 +153,23 @@ func TestAppend(t *testing.T) {
 	require.NoError(t, err)
 	vec.Free(mp)
 	require.Equal(t, int64(0), mp.CurrNB())
+
+	{
+		// Embedding
+		mp := mpool.MustNewZero()
+		vec := NewVec(types.New(types.T_float32vec, 4, 0))
+		err := AppendFixed(vec, types.Float32Vector{1, 2, 3, 0}, false, mp)
+		require.NoError(t, err)
+		require.Equal(t, 1, vec.Length())
+		err = AppendFixed(vec, types.Float32Vector{2, 4, 5, 6}, true, mp)
+		require.NoError(t, err)
+		require.Equal(t, 2, vec.Length())
+		err = AppendFixedList(vec, []types.Float32Vector{{4, 4, 4, 6}, {2, 5, 5, 3}}, nil, mp)
+		require.NoError(t, err)
+		require.Equal(t, 4, vec.Length())
+		vec.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestAppendBytes(t *testing.T) {
@@ -139,22 +190,50 @@ func TestAppendBytes(t *testing.T) {
 }
 
 func TestDup(t *testing.T) {
-	mp := mpool.MustNewZero()
-	v := NewVec(types.T_int8.ToType())
-	err := AppendFixedList(v, []int8{0, 1, 2}, nil, mp)
-	require.NoError(t, err)
-	w, err := v.Dup(mp)
-	require.NoError(t, err)
-	vs := MustFixedCol[int8](v)
-	ws := MustFixedCol[int8](w)
-	require.Equal(t, vs, ws)
-	v.Free(mp)
-	w.Free(mp)
-	require.Equal(t, int64(0), mp.CurrNB())
+	//mp := mpool.MustNewZero()
+	//v := NewVec(types.T_int8.ToType())
+	//err := AppendFixedList(v, []int8{0, 1, 2}, nil, mp)
+	//require.NoError(t, err)
+	//w, err := v.Dup(mp)
+	//require.NoError(t, err)
+	//vs := MustFixedCol[int8](v)
+	//ws := MustFixedCol[int8](w)
+	//require.Equal(t, vs, ws)
+	//v.Free(mp)
+	//w.Free(mp)
+	//require.Equal(t, int64(0), mp.CurrNB())
+
+	{
+		mp := mpool.MustNewZero()
+		v := NewVec(types.T_float32vec.ToType())
+		err := AppendFixedList(v, []types.Float32Vector{{0, 1, 2}, {3, 4, 5}}, nil, mp)
+		require.NoError(t, err)
+		w, err := v.Dup(mp)
+		require.NoError(t, err)
+		vs := MustFixedCol[types.Float32Vector](v)
+		ws := MustFixedCol[types.Float32Vector](w)
+		require.Equal(t, vs, ws)
+		v.Free(mp)
+		w.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestShrink(t *testing.T) {
 	mp := mpool.MustNewZero()
+	{ // embedding
+		vs := make([]types.Float32Vector, 4)
+		for i := 0; i < 4; i++ {
+			vs[i] = make(types.Float32Vector, 3)
+		}
+		v := NewVec(types.New(types.T_float32vec, 3, 0))
+		err := AppendFixedList(v, vs, nil, mp)
+		require.NoError(t, err)
+		v.Shrink([]int64{1, 2}, false)
+		require.Equal(t, vs[1:3], MustFixedCol[types.Float32Vector](v))
+		v.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 	{ // bool
 		v := NewVec(types.T_bool.ToType())
 		err := AppendFixedList(v, []bool{true, false, true, false}, nil, mp)
@@ -380,6 +459,21 @@ func TestShrink(t *testing.T) {
 
 func TestShuffle(t *testing.T) {
 	mp := mpool.MustNewZero()
+
+	{ // embedding
+		vs := make([]types.Float32Vector, 4)
+		for i := 0; i < 4; i++ {
+			vs[i] = make(types.Float32Vector, 3)
+		}
+		v := NewVec(types.T_float32vec.ToType())
+		err := AppendFixedList(v, vs, nil, mp)
+		require.NoError(t, err)
+		v.Shuffle([]int64{1, 2}, mp)
+		require.Equal(t, vs[1:3], MustFixedCol[types.Float32Vector](v))
+		require.Equal(t, "[[0 0 0] [0 0 0]]-[]", v.String())
+		v.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 	{ // bool
 		v := NewVec(types.T_bool.ToType())
 		err := AppendFixedList(v, []bool{true, false, true, false}, nil, mp)
@@ -639,6 +733,19 @@ func TestCopy(t *testing.T) {
 		w.Free(mp)
 		require.Equal(t, int64(0), mp.CurrNB())
 	}
+	{ // embedding
+		v := NewVec(types.New(types.T_float32vec, 2, 0))
+		AppendFixedList(v, []types.Float32Vector{{0, 1}, {2, 3}, {0, 0}, {6, 7}}, nil, mp)
+		w := NewVec(types.New(types.T_float32vec, 2, 0))
+		AppendFixedList(w, []types.Float32Vector{{0, 1}, {2, 3}, {4, 5}, {6, 7}}, nil, mp)
+		//TODO: Not working. Value not getting copied.
+		err := v.Copy(w, 2, 0, mp)
+		require.NoError(t, err)
+		require.Equal(t, MustFixedCol[types.Float32Vector](v), MustFixedCol[types.Float32Vector](w))
+		v.Free(mp)
+		w.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 	{ // string
 		v := NewVec(types.New(types.T_char, 10, 0))
 		AppendBytesList(v, [][]byte{
@@ -695,6 +802,29 @@ func TestCloneWindowWithMpNil(t *testing.T) {
 	require.Equal(t, 1, len(vec4.GetBytesAt(0)))
 	require.Equal(t, 3, len(vec4.GetBytesAt(2)))
 	require.True(t, vec4.GetNulls().Contains(uint64(1)))
+
+	{ //embedding
+		mp := mpool.MustNewZero()
+		vec5 := NewVec(types.New(types.T_float32vec, 2, 0))
+		AppendFixed(vec5, types.Float32Vector{1, 1}, false, mp)
+		AppendFixed(vec5, types.Float32Vector{2, 2}, true, mp)
+		AppendFixed(vec5, types.Float32Vector{3, 3}, false, mp)
+		require.False(t, vec5.NeedDup())
+
+		vec6, err := vec5.CloneWindow(0, vec5.Length(), nil)
+		require.NoError(t, err)
+		vec5.Free(mp)
+
+		t.Log(vec6.String())
+		require.True(t, vec6.NeedDup())
+		require.Equal(t, types.Float32Vector{1, 1}, GetFixedAt[types.Float32Vector](vec6, 0))
+		require.True(t, vec6.GetNulls().Contains(uint64(1)))
+		//TODO: Error unexpected fault address 0xb0000000b
+		//fatal error: fault
+		//[signal SIGSEGV: segmentation violation code=0x2 addr=0xb0000000b pc=0x1004bb7a0]
+		require.Equal(t, types.Float32Vector{3, 3}, GetFixedAt[types.Float32Vector](vec6, 2))
+
+	}
 }
 
 /*
@@ -1021,6 +1151,31 @@ func TestMarshalAndUnMarshal(t *testing.T) {
 	v.Free(mp)
 	w.Free(mp)
 	require.Equal(t, int64(0), mp.CurrNB())
+
+	{
+		// encoding
+		mp := mpool.MustNewZero()
+		v := NewVec(types.New(types.T_float32vec, 2, 0))
+		err := AppendFixedList(v, []types.Float32Vector{{0, 0}, {1, 1}, {2, 2}}, nil, mp)
+		require.NoError(t, err)
+		data, err := v.MarshalBinary()
+		require.NoError(t, err)
+		w := new(Vector)
+		err = w.UnmarshalBinary(data)
+		require.NoError(t, err)
+		//TODO: Error:unexpected fault address 0x56323374616f6c46
+		//fatal error: fault
+		//[signal SIGSEGV: segmentation violation code=0x2 addr=0x56323374616f6c46 pc=0x1041ffb10]
+		require.Equal(t, MustFixedCol[types.Float32Vector](v), MustFixedCol[types.Float32Vector](w))
+		w = new(Vector)
+		err = w.UnmarshalBinaryWithCopy(data, mp)
+		require.NoError(t, err)
+		require.Equal(t, MustFixedCol[types.Float32Vector](v), MustFixedCol[types.Float32Vector](w))
+		require.NoError(t, err)
+		v.Free(mp)
+		w.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestStrMarshalAndUnMarshal(t *testing.T) {
@@ -1044,6 +1199,7 @@ func TestStrMarshalAndUnMarshal(t *testing.T) {
 }
 
 func TestWindowWith(t *testing.T) {
+	//TODO: Pending
 	mp := mpool.MustNewZero()
 	vec1 := NewVec(types.T_int32.ToType())
 	AppendFixed(vec1, int32(1), false, mp)
@@ -1107,6 +1263,7 @@ func TestWindowWith(t *testing.T) {
 }
 
 func TestSetFunction(t *testing.T) {
+	//TODO: Pending
 	mp := mpool.MustNewZero()
 	{ // bool
 		v := NewVec(types.T_bool.ToType())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [X] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

### Registering Embedding to Vector Types.

There are a couple of strategies of doing this.

1. [Using Width and register Embedding ](https://github.com/arjunsk/matrixone/pull/34)as `type Embedding float32[]`

Problem: Dealing with TypeSize()
```go
func DecodeFixedCol[T types.FixedSizeT](v *Vector) []T {
	sz := int(v.typ.TypeSize()) // TypeSize is not defined for FloatVector

	if cap(v.data) >= sz {
		return unsafe.Slice((*T)(unsafe.Pointer(&v.data[0])), cap(v.data)/sz)
	}
	return nil
}
```
Currently TypeSize() is solved using 
```go
func (t Type) TypeSize() int {
	if t.Oid == T_float32vec {
		return int(t.Width * t.Size)
	}
	return int(t.Size)
}
```

2. Using [Varlena](https://github.com/arjunsk/matrixone/pull/35)
The approach seems to be simple and flexible. Dimension of the Embedding is fixed, hence we might not be really benefiting from having Varlena's support. However, I see that T_char also uses Varlena, hence I think we can use it for Embedding with Fixed Dimension as well.

Problem: Right now area saves bytes. We may encounter serialization/deserialization overhead.