### PR TITLE
The CGO call is expensive than native L2Distance impl in Golang.

### DIFF
--- a/etc/launch/cn.toml
+++ b/etc/launch/cn.toml
@@ -12,3 +12,16 @@ port-base = 18000
 check-fraction = 65536
 enable-metrics = true
 
+[[fileservice]]
+name = "LOCAL"
+backend = "DISK"
+
+[[fileservice]]
+name = "SHARED"
+backend = "DISK"
+data-dir = "mo-data/shared"
+
+[fileservice.cache]
+memory-capacity = "6GB"
+disk-capacity = "8GB"
+disk-path = "mo-data/file-service-cache"

--- a/pkg/vectorize/moarray/external.go
+++ b/pkg/vectorize/moarray/external.go
@@ -14,12 +14,38 @@
 
 package moarray
 
+/*
+#include <stdlib.h>
+
+// C function to calculate the squared L2 distance between two vectors of floats
+float L2DistanceSqFloat32(int dim, float *ax, float *bx) {
+    float distance = 0.0;
+    for (int i = 0; i < dim; i++) {
+        float diff = ax[i] - bx[i];
+        distance += diff * diff;
+    }
+    return distance;
+}
+
+// C function to calculate the squared L2 distance between two vectors of doubles
+double L2DistanceSqFloat64(int dim, double *ax, double *bx) {
+    double distance = 0.0;
+    for (int i = 0; i < dim; i++) {
+        double diff = ax[i] - bx[i];
+        distance += diff * diff;
+    }
+    return distance;
+}
+*/
+import "C"
 import (
+	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/vectorize/momath"
 	"gonum.org/v1/gonum/mat"
 	"math"
+	"unsafe"
 )
 
 // These functions are exposed externally via SQL API.
@@ -121,19 +147,26 @@ func L2Distance[T types.RealNumbers](v1, v2 []T) (float64, error) {
 	return math.Sqrt(float64(sumOfSquares)), nil
 }
 
-// L2DistanceSq returns the squared L2 distance between two vectors.
-// It is an optimized version of L2Distance used in Index Scan
-func L2DistanceSq[T types.RealNumbers](v1, v2 []T) (float64, error) {
-	if len(v1) != len(v2) {
-		return 0, moerr.NewArrayInvalidOpNoCtx(len(v1), len(v2))
+// L2DistanceSq calculates the squared L2 distance between two vectors using CGO and generics.
+func L2DistanceSq[T types.RealNumbers](ax, bx []T) (float64, error) {
+	if len(ax) != len(bx) {
+		return 0, fmt.Errorf("vectors must be of the same length")
 	}
-	var sumOfSquares T
-	var difference T
-	for i := range v1 {
-		difference = v1[i] - v2[i]
-		sumOfSquares += difference * difference
+
+	switch any(ax).(type) {
+	case []float32:
+		cAx := (*C.float)(unsafe.Pointer(&ax[0]))
+		cBx := (*C.float)(unsafe.Pointer(&bx[0]))
+		dim := C.int(len(ax))
+		return float64(C.L2DistanceSqFloat32(dim, cAx, cBx)), nil
+	case []float64:
+		cAx := (*C.double)(unsafe.Pointer(&ax[0]))
+		cBx := (*C.double)(unsafe.Pointer(&bx[0]))
+		dim := C.int(len(ax))
+		return float64(C.L2DistanceSqFloat64(dim, cAx, cBx)), nil
+	default:
+		return 0, fmt.Errorf("unsupported element type %T", ax)
 	}
-	return float64(sumOfSquares), nil
 }
 
 func CosineDistance[T types.RealNumbers](v1, v2 []T) (float64, error) {

--- a/pkg/vectorize/moarray/external_test.go
+++ b/pkg/vectorize/moarray/external_test.go
@@ -803,6 +803,49 @@ func TestL2Distance(t *testing.T) {
 	}
 }
 
+func TestL2DistanceSq(t *testing.T) {
+	type args struct {
+		argLeftF32  []float32
+		argRightF32 []float32
+
+		argLeftF64  []float64
+		argRightF64 []float64
+	}
+	type testCase struct {
+		name string
+		args args
+		want float64
+	}
+	tests := []testCase{
+		{
+			name: "Test1 - float32",
+			args: args{argLeftF32: []float32{0, 0, 0}, argRightF32: []float32{3, 4, 0}},
+			want: 25,
+		},
+		{
+			name: "Test2 - float64",
+			args: args{argLeftF64: []float64{0, 0, 0}, argRightF64: []float64{3, 4, 0}},
+			want: 25,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.args.argLeftF32 != nil {
+				if gotRes, _ := L2DistanceSq[float32](tt.args.argLeftF32, tt.args.argRightF32); !assertx.InEpsilonF64(tt.want, gotRes) {
+					t.Errorf("L2Distance() = %v, want %v", gotRes, tt.want)
+				}
+			}
+			if tt.args.argLeftF64 != nil {
+				if gotRes, _ := L2DistanceSq[float64](tt.args.argLeftF64, tt.args.argRightF64); !assertx.InEpsilonF64(tt.want, gotRes) {
+					t.Errorf("L2Distance() = %v, want %v", gotRes, tt.want)
+				}
+			}
+
+		})
+	}
+}
+
 func TestCosineDistance(t *testing.T) {
 	type args struct {
 		argLeftF32  []float32


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

The CGO Call (18QPS) is more expensive than the Golang Native L2Distance (26 QPS)

##### CGO
![image](https://github.com/matrixorigin/matrixone/assets/9638314/4528efb6-987d-40e3-afda-a77a894b7f1e)

##### Native
![image](https://github.com/arjunsk/matrixone/assets/9638314/3e493780-e95c-404c-ab02-2530ecf71f60)
